### PR TITLE
Implement OpGroupNonUniformBroadcastFirst

### DIFF
--- a/include/sirit/sirit.h
+++ b/include/sirit/sirit.h
@@ -1212,6 +1212,10 @@ public:
     // the group.
     Id OpGroupNonUniformBroadcast(Id result_type, Id scope, Id value, Id id);
 
+    // Result is the Value of the invocation from the active invocation with the lowest id
+    // in the group to all active invocations in the group.
+    Id OpGroupNonUniformBroadcastFirst(Id result_type, Id scope, Id value);
+
     /// Return the value of the invocation identified by the current invocation's id within the
     /// group xor'ed with mask.
     Id OpGroupNonUniformShuffleXor(Id result_type, Id scope, Id value, Id mask);

--- a/src/instructions/group.cpp
+++ b/src/instructions/group.cpp
@@ -42,6 +42,12 @@ Id Module::OpGroupNonUniformBroadcast(Id result_type, Id scope, Id value, Id id)
                  << id << EndOp{};
 }
 
+Id Module::OpGroupNonUniformBroadcastFirst(Id result_type, Id scope, Id value) {
+    code->Reserve(5);
+    return *code << OpId{spv::Op::OpGroupNonUniformBroadcastFirst, result_type} << scope << value
+                 << EndOp{};
+}
+
 Id Module::OpGroupNonUniformShuffleXor(Id result_type, Id scope, Id value, Id mask) {
     code->Reserve(6);
     return *code << OpId{spv::Op::OpGroupNonUniformShuffleXor, result_type} << scope << value


### PR DESCRIPTION
- update to latest spirv-headers
- add OpGroupNonUniformBroadcastFirst

Can be use in order to properly implement V_READFIRSTLANE_B32