### PR TITLE
Add SPV_AMD_gcn_shader instructions.

### DIFF
--- a/include/sirit/sirit.h
+++ b/include/sirit/sirit.h
@@ -261,7 +261,7 @@ public:
         OpPhi(Id result_type, Ts&&... operands) {
         return OpPhi(result_type, std::span<const Id>({operands...}));
     }
-    
+
     /**
      * The SSA phi function. This instruction will be revisited when patching phi nodes.
      *
@@ -1355,9 +1355,24 @@ public:
     // Usage is like C printf
     Id OpDebugPrintf(Id fmt, std::span<const Id> fmt_args);
 
+    /// Returns a two-component floating point vector that represents the 2D texture coordinates
+    /// that would be used for accessing the selected cube map face for the given cube map texture
+    /// coordinates given as a parameter.
+    Id OpCubeFaceCoordAMD(Id result_type, Id cube_coords);
+
+    /// Returns a single floating point value that represents the index of the cube map face that
+    /// would be accessed by texture lookup functions for the cube map texture coordinates given
+    /// as parameter.
+    Id OpCubeFaceIndexAMD(Id result_type, Id cube_coords);
+
+    /// Returns a 64-bit value representing the current execution clock as seen by the shader
+    /// processor.
+    Id OpTimeAMD(Id result_type);
+
 private:
     Id GetGLSLstd450();
     Id GetNonSemanticDebugPrintf();
+    Id GetAmdGcnShader();
 
     std::uint32_t version{};
     std::uint32_t bound{};
@@ -1366,6 +1381,7 @@ private:
     std::unordered_set<spv::Capability> capabilities;
     std::optional<Id> glsl_std_450;
     std::optional<Id> non_semantic_debug_printf;
+    std::optional<Id> amd_gcn_shader;
 
     spv::AddressingModel addressing_model{spv::AddressingModel::Logical};
     spv::MemoryModel memory_model{spv::MemoryModel::GLSL450};

--- a/src/instructions/extension.cpp
+++ b/src/instructions/extension.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <iterator>
+#include <spirv/unified1/AMD_gcn_shader.h>
 #include <spirv/unified1/GLSL.std.450.h>
 #include <spirv/unified1/NonSemanticDebugPrintf.h>
 
@@ -89,6 +90,18 @@ Id Module::OpDebugPrintf(Id fmt, std::span<const Id> fmt_args) {
     std::copy(fmt_args.begin(), fmt_args.end(), std::back_inserter(operands));
     return OpExtInst(TypeVoid(), GetNonSemanticDebugPrintf(), NonSemanticDebugPrintfDebugPrintf,
                      operands);
+}
+
+Id Module::OpCubeFaceCoordAMD(Id result_type, Id cube_coords) {
+    return OpExtInst(result_type, GetAmdGcnShader(), AMD_gcn_shaderCubeFaceCoordAMD, cube_coords);
+}
+
+Id Module::OpCubeFaceIndexAMD(Id result_type, Id cube_coords) {
+    return OpExtInst(result_type, GetAmdGcnShader(), AMD_gcn_shaderCubeFaceIndexAMD, cube_coords);
+}
+
+Id Module::OpTimeAMD(Id result_type) {
+    return OpExtInst(result_type, GetAmdGcnShader(), AMD_gcn_shaderTimeAMD);
 }
 
 } // namespace Sirit

--- a/src/sirit.cpp
+++ b/src/sirit.cpp
@@ -152,4 +152,14 @@ Id Module::GetNonSemanticDebugPrintf() {
     return *non_semantic_debug_printf;
 }
 
+Id Module::GetAmdGcnShader() {
+    const char* extname = "SPV_AMD_gcn_shader";
+    size_t len = WordsInString(extname);
+    if (!amd_gcn_shader) {
+        ext_inst_imports->Reserve(3 + len);
+        amd_gcn_shader = *ext_inst_imports << OpId{spv::Op::OpExtInstImport} << extname << EndOp{};
+    }
+    return *amd_gcn_shader;
+}
+
 } // namespace Sirit


### PR DESCRIPTION
Adds instructions provided by the `SPV_AMD_gcn_shader` instruction. Will be useful for the cube instructions.