### PR TITLE
Corretly implement memory access

### DIFF
--- a/include/sirit/sirit.h
+++ b/include/sirit/sirit.h
@@ -32,6 +32,8 @@ class Stream;
 using Literal =
     std::variant<std::uint32_t, std::uint64_t, std::int32_t, std::int64_t, float, double>;
 
+using MemoryAccessLiteral = std::variant<spv::MemoryAccessMask, std::uint32_t>;
+
 struct Id {
     std::uint32_t value;
 };
@@ -345,11 +347,25 @@ public:
 
     /// Load through a pointer.
     Id OpLoad(Id result_type, Id pointer,
-              std::optional<spv::MemoryAccessMask> memory_access = std::nullopt);
+        std::span<const MemoryAccessLiteral> memory_access = {});
+
+    /// Load through a pointer.
+    template <typename... Ts>
+    requires(...&& std::is_convertible_v<Ts, MemoryAccessLiteral>) Id
+        OpLoad(Id result_type, Id pointer, Ts&&... memory_access) {
+        return OpLoad(result_type, pointer, std::span<const MemoryAccessLiteral>({memory_access...}));
+    }
 
     /// Store through a pointer.
     Id OpStore(Id pointer, Id object,
-               std::optional<spv::MemoryAccessMask> memory_access = std::nullopt);
+               std::span<const MemoryAccessLiteral> memory_access = {});
+
+    /// Store through a pointer.
+    template <typename... Ts>
+    requires(...&& std::is_convertible_v<Ts, MemoryAccessLiteral>) Id
+        OpStore(Id pointer, Id object, Ts&&... memory_access) {
+        return OpStore(pointer, object, std::span<const MemoryAccessLiteral>({memory_access...}));
+    }
 
     /// Create a pointer into a composite object that can be used with OpLoad and OpStore.
     Id OpAccessChain(Id result_type, Id base, std::span<const Id> indexes = {});

--- a/src/instructions/memory.cpp
+++ b/src/instructions/memory.cpp
@@ -18,13 +18,13 @@ Id Module::OpImageTexelPointer(Id result_type, Id image, Id coordinate, Id sampl
                  << EndOp{};
 }
 
-Id Module::OpLoad(Id result_type, Id pointer, std::optional<spv::MemoryAccessMask> memory_access) {
-    code->Reserve(5);
+Id Module::OpLoad(Id result_type, Id pointer, std::span<const MemoryAccessLiteral> memory_access) {
+    code->Reserve(4 + memory_access.size());
     return *code << OpId{spv::Op::OpLoad, result_type} << pointer << memory_access << EndOp{};
 }
 
-Id Module::OpStore(Id pointer, Id object, std::optional<spv::MemoryAccessMask> memory_access) {
-    code->Reserve(4);
+Id Module::OpStore(Id pointer, Id object, std::span<const MemoryAccessLiteral> memory_access) {
+    code->Reserve(3 + memory_access.size());
     return *code << spv::Op::OpStore << pointer << object << memory_access << EndOp{};
 }
 

--- a/src/stream.h
+++ b/src/stream.h
@@ -167,6 +167,11 @@ public:
         return *this;
     }
 
+    Stream& operator<<(const MemoryAccessLiteral& memory_access) {
+        std::visit([this](auto value) { *this << value; }, memory_access);
+        return *this;
+    }
+
     Stream& operator<<(std::string_view string) {
         InsertStringView(words, insert_index, string);
         return *this;


### PR DESCRIPTION
This allows you to do:

```c++
OpLoad(type, addr_ptr, spv::MemoryAccessMask::Aligned, 4u);
```

Some Opcodes may have more than 1 word for the MemoryAccess.