### PR TITLE
Fix CMake compiler flags causing issues on Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,13 +75,18 @@ if (msvc AND NOT clang)
     endif()
 else()
     set(SIRIT_CXX_FLAGS
-        -Wcast-qual
-        -pedantic
-        -Wfatal-errors
+        -Wall
+        -Wextra
+        -Wpedantic
         -Wno-missing-braces
-        -Wconversion
-        -Wsign-conversion
-        -Wshadow)
+        -Wno-unused-parameter
+        -Wno-unknown-pragmas
+        -Wno-implicit-fallthrough
+        -Wno-unused-variable
+        -Wno-c++98-compat
+        -Wno-pre-c++14-compa
+        -Wno-pre-c++17-compat
+        -Wno-sign-compare)
 endif()
 
 # Enable unit-testing.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,8 +38,13 @@ endif()
 # Add the module directory to the list of paths
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/CMakeModules")
 
+# Set compiler ID
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  set(msvc TRUE)
+endif()
+
 # Compiler flags
-if (MSVC)
+if (msvc)
     set(SIRIT_CXX_FLAGS
         /std:c++latest # CMAKE_CXX_STANDARD as no effect on MSVC until CMake 3.10.
         /W4
@@ -57,8 +62,7 @@ if (MSVC)
         /Zo
         /EHsc
         /Zc:inline # Omits inline functions from object-file output
-        /DNOMINMAX
-        /WX)
+        /DNOMINMAX)
 
     if (CMAKE_VS_PLATFORM_TOOLSET MATCHES "LLVM-vs[0-9]+")
         list(APPEND SIRIT_CXX_FLAGS
@@ -76,8 +80,7 @@ else()
         -Wno-missing-braces
         -Wconversion
         -Wsign-conversion
-        -Wshadow
-        -Werror)
+        -Wshadow)
 endif()
 
 # Enable unit-testing.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,6 @@ endif()
 # Compiler flags
 if (msvc AND NOT clang)
     set(SIRIT_CXX_FLAGS
-        /std:c++latest # CMAKE_CXX_STANDARD as no effect on MSVC until CMake 3.10.
         /W4
         /w34263 # Non-virtual member function hides base class virtual function
         /w44265 # Class has virtual functions, but destructor is not virtual

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,17 @@ endif()
 # Compiler flags
 if (msvc AND NOT clang)
     set(SIRIT_CXX_FLAGS
+        /std:c++latest # CMAKE_CXX_STANDARD as no effect on MSVC until CMake 3.10.
+        /w34263 # Non-virtual member function hides base class virtual function
+        /w44265 # Class has virtual functions, but destructor is not virtual
+        /w34456 # Declaration of 'var' hides previous local declaration
+        /w34457 # Declaration of 'var' hides function parameter
+        /w34458 # Declaration of 'var' hides class member
+        /w34459 # Declaration of 'var' hides global definition
+        /w34946 # Reinterpret-cast between related types
+        /wd4592 # Symbol will be dynamically initialized (implementation limitation)
         /permissive- # Stricter C++ standards conformance
+        /MP
         /Zi
         /Zo
         /EHsc
@@ -64,7 +74,6 @@ if (msvc AND NOT clang)
     endif()
 else()
     set(SIRIT_CXX_FLAGS
-        -Wall
         -Wextra
         -Wcast-qual
         -pedantic

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,23 +41,16 @@ list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/CMakeModules")
 # Set compiler ID
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   set(msvc TRUE)
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  set(gcc TRUE)
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  set(clang TRUE)
 endif()
 
 # Compiler flags
-if (msvc)
+if (msvc AND NOT clang)
     set(SIRIT_CXX_FLAGS
-        /std:c++latest # CMAKE_CXX_STANDARD as no effect on MSVC until CMake 3.10.
-        /W4
-        /w34263 # Non-virtual member function hides base class virtual function
-        /w44265 # Class has virtual functions, but destructor is not virtual
-        /w34456 # Declaration of 'var' hides previous local declaration
-        /w34457 # Declaration of 'var' hides function parameter
-        /w34458 # Declaration of 'var' hides class member
-        /w34459 # Declaration of 'var' hides global definition
-        /w34946 # Reinterpret-cast between related types
-        /wd4592 # Symbol will be dynamically initialized (implementation limitation)
         /permissive- # Stricter C++ standards conformance
-        /MP
         /Zi
         /Zo
         /EHsc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,16 +75,16 @@ if (msvc AND NOT clang)
     endif()
 else()
     set(SIRIT_CXX_FLAGS
-        -Wall
+        #-Wall
         -Wextra
-        -Wpedantic
         -Wno-missing-braces
         -Wno-unused-parameter
         -Wno-unknown-pragmas
         -Wno-implicit-fallthrough
         -Wno-unused-variable
         -Wno-c++98-compat
-        -Wno-pre-c++14-compa
+        -Wno-c++98-compat-pedantic
+        -Wno-pre-c++14-compat
         -Wno-pre-c++17-compat
         -Wno-sign-compare)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ endif()
 if (msvc AND NOT clang)
     set(SIRIT_CXX_FLAGS
         /std:c++latest # CMAKE_CXX_STANDARD as no effect on MSVC until CMake 3.10.
+        /W4
         /w34263 # Non-virtual member function hides base class virtual function
         /w44265 # Class has virtual functions, but destructor is not virtual
         /w34456 # Declaration of 'var' hides previous local declaration
@@ -74,10 +75,8 @@ if (msvc AND NOT clang)
     endif()
 else()
     set(SIRIT_CXX_FLAGS
-        -Wextra
         -Wcast-qual
         -pedantic
-        -pedantic-errors
         -Wfatal-errors
         -Wno-missing-braces
         -Wconversion


### PR DESCRIPTION
I'd be happy to remove my changes for -Wall, but it was causing issues in my CI, so I disabled it.
The problem is, on GitHub CI, clang is showing as MSVC when it shouldn't, and overwriting SIRIT_CXX_FLAGS doesn't do much depending on how you import sirit